### PR TITLE
resetFields() has been added to cancel event in view/edit mode

### DIFF
--- a/example/src/examples/ViewEdit.js
+++ b/example/src/examples/ViewEdit.js
@@ -73,7 +73,7 @@ export default Form.create()(({ form }) => {
             <Button htmlType="submit" type="primary" disabled={pending}>
               {pending ? 'Updating...' : 'Update'}
             </Button>
-            <Button onClick={() => setViewMode(true)} style={{ marginLeft: '15px' }}>
+            <Button onClick={() => { form.resetFields(); setViewMode(true) }} style={{ marginLeft: '15px' }}>
               Cancel
             </Button>
           </Form.Item>


### PR DESCRIPTION
When the form is filled in View/Edit mode and press cancel, the form values which requested to be canceled are displayed on the view screen. So I've added `form.resetFields()` to cancel button's onClick event.