### PR TITLE
fix: options format support {value, label} style

### DIFF
--- a/src/defineAntdWidgets.js
+++ b/src/defineAntdWidgets.js
@@ -8,16 +8,13 @@ const mapOptions = options => {
     throw new Error('Options should be array in form builder meta.')
   }
   return options.map(opt => {
-    let value
-    let label
     if (_.isArray(opt)) {
-      value = opt[0]
-      label = opt[1]
+      return {value: opt[0], label: opt[1]}
+    } else if(_.isPlainObject(opt)) {
+      return opt
     } else {
-      value = opt
-      label = opt
+      return {value: opt, label: opt}
     }
-    return { value, label }
   })
 }
 


### PR DESCRIPTION
fix `options` not support the format on the document