### PR TITLE
Remove default required rule error message

### DIFF
--- a/src/FormBuilderField.js
+++ b/src/FormBuilderField.js
@@ -135,10 +135,7 @@ function FormBuilderField(props) {
   // Handle field props
   const rules = [...(field.rules || [])]
   if (field.required) {
-    rules.unshift({
-      required: true,
-      message: field.message || `${field.label || field.key} is required.`, // default to English, if needs localization, define it in fieldProps.rules.
-    })
+    rules.unshift({ required: true });
   }
   const fieldProps = {
     initialValue,


### PR DESCRIPTION
# Why? 

Because;
1. It's a pain to assign a custom localized error message to every required field.
2. It'd be better to leave the defaults to Ant Design as much as possible, especially defaults for localized messages, so we can define them in one place (ie. antd `ConfigProvider` component) and make sure every component uses them.

Closes #42 