### PR TITLE
Allow option children in default 'select' widget

### DIFF
--- a/src/defineAntdWidgets.js
+++ b/src/defineAntdWidgets.js
@@ -71,7 +71,7 @@ FormBuilder.defineWidget('select', Select, field => {
       ...field,
       children: mapOptions(field.options).map(opt => (
         <Select.Option value={opt.value} key={opt.value} disabled={opt.disabled}>
-          {opt.label}
+          {opt.children || opt.label}
         </Select.Option>
       )),
     }

--- a/src/defineAntdWidgets.js
+++ b/src/defineAntdWidgets.js
@@ -70,7 +70,7 @@ FormBuilder.defineWidget('select', Select, field => {
     return {
       ...field,
       children: mapOptions(field.options).map(opt => (
-        <Select.Option value={opt.value} key={opt.value} disabled={opt.disabled}>
+        <Select.Option label={opt.label} value={opt.value} key={opt.value} disabled={opt.disabled}>
           {opt.children || opt.label}
         </Select.Option>
       )),


### PR DESCRIPTION
Allow custom selection render by accepting a `children` prop in default 'select' widget options. See https://ant.design/components/select/#components-select-demo-option-label-prop